### PR TITLE
Adapt readiness for checking active app

### DIFF
--- a/NAKL/AppDelegate.m
+++ b/NAKL/AppDelegate.m
@@ -37,6 +37,7 @@ KeyboardHandler *kbHandler;
 
 static char rk = 0;
 bool dirty;
+bool osFrom1070 = true;
 
 #pragma mark Initialization
 
@@ -46,6 +47,10 @@ bool dirty;
     NSMutableDictionary *appDefs = [NSMutableDictionary dictionary];
     [appDefs setObject:[NSNumber numberWithInt:1] forKey:NAKL_KEYBOARD_METHOD];
     [defaults registerDefaults:appDefs];
+    
+    if (floor(NSAppKitVersionNumber) < NSAppKitVersionNumber10_7) {
+        osFrom1070 = false;
+    }
     
     BOOL accessibilityEnabled = YES;
     
@@ -131,13 +136,13 @@ CGEventRef KeyHandler(CGEventTapProxy proxy, CGEventType type, CGEventRef event,
     long i;
     NSString *activeAppBundleId;
     
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-    NSRunningApplication *activeApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
-    activeAppBundleId = [activeApp bundleIdentifier];
-#else
-    NSDictionary *activeApp = [[NSWorkspace sharedWorkspace] activeApplication];
-    activeAppBundleId = [activeApp objectForKey:@"NSApplicationBundleIdentifier"];
-#endif
+    if (osFrom1070) {
+        NSRunningApplication *activeApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
+        activeAppBundleId = [activeApp bundleIdentifier];
+    } else {
+        NSDictionary *activeApp = [[NSWorkspace sharedWorkspace] activeApplication];
+        activeAppBundleId = [activeApp objectForKey:@"NSApplicationBundleIdentifier"];
+    }
 
     uint64_t flag = CGEventGetFlags(event);
     

--- a/NAKL/AppDelegate.m
+++ b/NAKL/AppDelegate.m
@@ -37,7 +37,7 @@ KeyboardHandler *kbHandler;
 
 static char rk = 0;
 bool dirty;
-bool osFrom1070 = true;
+static bool frontmostAppApiCompatible = false;
 
 #pragma mark Initialization
 
@@ -48,8 +48,8 @@ bool osFrom1070 = true;
     [appDefs setObject:[NSNumber numberWithInt:1] forKey:NAKL_KEYBOARD_METHOD];
     [defaults registerDefaults:appDefs];
     
-    if (floor(NSAppKitVersionNumber) < NSAppKitVersionNumber10_7) {
-        osFrom1070 = false;
+    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_7) {
+        frontmostAppApiCompatible = true;
     }
     
     BOOL accessibilityEnabled = YES;
@@ -136,7 +136,7 @@ CGEventRef KeyHandler(CGEventTapProxy proxy, CGEventType type, CGEventRef event,
     long i;
     NSString *activeAppBundleId;
     
-    if (osFrom1070) {
+    if (frontmostAppApiCompatible) {
         NSRunningApplication *activeApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
         activeAppBundleId = [activeApp bundleIdentifier];
     } else {

--- a/NAKL/AppDelegate.m
+++ b/NAKL/AppDelegate.m
@@ -129,9 +129,15 @@ CGEventRef KeyHandler(CGEventTapProxy proxy, CGEventType type, CGEventRef event,
     UniChar chars[3];
     UniChar *x;
     long i;
+    NSString *activeAppBundleId;
     
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+    NSRunningApplication *activeApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
+    activeAppBundleId = [activeApp bundleIdentifier];
+#else
     NSDictionary *activeApp = [[NSWorkspace sharedWorkspace] activeApplication];
-    NSString *activeAppBundleId = [activeApp objectForKey:@"NSApplicationBundleIdentifier"];
+    activeAppBundleId = [activeApp objectForKey:@"NSApplicationBundleIdentifier"];
+#endif
 
     uint64_t flag = CGEventGetFlags(event);
     

--- a/NAKL/ExcludedAppsTableViewController.m
+++ b/NAKL/ExcludedAppsTableViewController.m
@@ -54,10 +54,12 @@
             NSDictionary* plistData = [NSDictionary dictionaryWithContentsOfFile:[path stringByAppendingString:@"/Contents/Info.plist"]];
             NSString *appBundleIdentifier = [plistData valueForKeyPath:@"CFBundleIdentifier"];
             NSString *appName = [plistData valueForKeyPath:@"CFBundleName"];
+            if (appName == nil || [appName isEqualToString:@""]) {
+                appName = [[path lastPathComponent] stringByDeletingPathExtension];
+            }
             if ((appBundleIdentifier != nil) && ![[AppData sharedAppData].excludedApps objectForKey:appBundleIdentifier]) {
                 [[AppData sharedAppData].excludedApps setObject:appName forKey:appBundleIdentifier];
                 [self.list addObject:appBundleIdentifier];
-                NSLog(@"Added");
             }
         }
         [[AppData sharedAppData].userPrefs setObject:[AppData sharedAppData].excludedApps forKey:NAKL_EXCLUDED_APPS];

--- a/NAKL/ExcludedAppsTableViewController.m
+++ b/NAKL/ExcludedAppsTableViewController.m
@@ -54,7 +54,7 @@
             NSDictionary* plistData = [NSDictionary dictionaryWithContentsOfFile:[path stringByAppendingString:@"/Contents/Info.plist"]];
             NSString *appBundleIdentifier = [plistData valueForKeyPath:@"CFBundleIdentifier"];
             NSString *appName = [plistData valueForKeyPath:@"CFBundleName"];
-            if (appName == nil || [appName isEqualToString:@""]) {
+            if ((appName == nil) || [appName isEqualToString:@""]) {
                 appName = [[path lastPathComponent] stringByDeletingPathExtension];
             }
             if ((appBundleIdentifier != nil) && ![[AppData sharedAppData].excludedApps objectForKey:appBundleIdentifier]) {


### PR DESCRIPTION
Adapt new checking for active app (in case the activeApplication is deprecated) and using filename in case the BundleName is empty.